### PR TITLE
Fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -22,6 +22,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: echo "Initialized; starting build process"
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
@@ -32,5 +36,8 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script
         run: |
+          npm install -g yarn
+          yarn install --frozen-lockfile
           yarn lint
           yarn prettier
+          yarn build


### PR DESCRIPTION
This should hopefully start passing (unless the actions runner doesn't recognize `next` as a command :')